### PR TITLE
ci: exclude taxonomy.xml from validation

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -31,7 +31,7 @@ jobs:
           echo "::set-output name=files::$( \
             git diff --name-only --diff-filter=ACMRT \
             ${{ github.event.pull_request.base.sha }} \
-            ${{ github.sha }} -- './**/*.xml,!./**/transkribus*.xml,!./**/facsimile*.xml' | xargs)"
+            ${{ github.sha }} -- ':./**/*.xml' ':!./**/taxonomy.xml' | xargs)"
       # Validate changed files against latest schema
       - name: Validate changed source files
         if: ${{ steps.changed.outputs.files != '' }}

--- a/.github/workflows/validate_push.yml
+++ b/.github/workflows/validate_push.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Validate files
         run: |
           find . -type f -name '*.xml' \
-            -not -name 'facsimile*' \
-            -not -name 'transkribus*' \
             -not -name 'taxonomy.xml' \
             -not -name 'build.xml' \
             -not -name 'repo.xml' \

--- a/.github/workflows/validate_push.yml
+++ b/.github/workflows/validate_push.yml
@@ -32,6 +32,7 @@ jobs:
           find . -type f -name '*.xml' \
             -not -name 'facsimile*' \
             -not -name 'transkribus*' \
+            -not -name 'taxonomy.xml' \
             -not -name 'build.xml' \
             -not -name 'repo.xml' \
             -not -name 'expath-pkg.xml' \


### PR DESCRIPTION
The last remaining xml-fragment that does not validate by itself against the schema.