### PR TITLE
church schools

### DIFF
--- a/ChurchSchools/MashafBet.xml
+++ b/ChurchSchools/MashafBet.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="auth" xml:id="MashafBet">
+   <teiHeader xml:base="https://betamasaheft.eu/">
+      <fileDesc>
+         <titleStmt>
+            <title>Maṣḥāf bet</title>
+            <editor key="ES"/>
+            <editor key="AB" role="generalEditor"/>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+            <pubPlace>Hamburg</pubPlace>
+            <availability>
+               <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                            licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                     href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+            <xi:fallback>
+               <p>Definitions of prefixes used.</p>
+            </xi:fallback>
+         </xi:include>
+      </encodingDesc>
+      <profileDesc>
+         <abstract><p>Church school (school of exegesis).
+            Can be divided into <seg xml:id="OldT">Old Testament exegesis</seg>,  <seg xml:id="NewT">New Testament exegesis</seg>, and <seg xml:id="Monastic">Monastic literature</seg>. The school uses and produces extensively <seg xml:id="Andemta">ʾAndǝmtā</seg> commentary texts.
+            See also          
+            <ref type="authFile" corresp="NebabBet"/>,  
+            <ref  type="authFile" corresp="QeddaseBet"></ref>,
+            <ref  type="authFile" corresp="ZemaBet"></ref>, <ref  type="authFile" corresp="QeneBet"></ref></p></abstract>
+      </profileDesc>
+      <revisionDesc>
+         <change who="ES" when="2025-07-15">created keyword</change>         
+      </revisionDesc>
+   </teiHeader>
+   <text xml:base="https://betamasaheft.eu/">
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/ChurchSchools/NebabBet.xml
+++ b/ChurchSchools/NebabBet.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="auth" xml:id="NebabBet">
+   <teiHeader xml:base="https://betamasaheft.eu/">
+      <fileDesc>
+         <titleStmt>
+            <title>Nǝbāb bet</title>
+            <editor key="ES"/>
+            <editor key="AB" role="generalEditor"/>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+            <pubPlace>Hamburg</pubPlace>
+            <availability>
+               <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                            licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                     href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+            <xi:fallback>
+               <p>Definitions of prefixes used.</p>
+            </xi:fallback>
+         </xi:include>
+      </encodingDesc>
+      <profileDesc>
+         <abstract><p>Church school (first stage, reading school). See also          
+            <ref type="authFile" corresp="QeddaseBet">Qǝddāse bet
+            </ref>,  
+            <ref  type="authFile" corresp="QeneBet">
+               Qǝne bet
+            </ref>,
+            <ref  type="authFile" corresp="ZemaBet">
+               Zemā bet
+            </ref>, <ref  type="authFile" corresp="MashafBet">
+               Maṣḥaf bet
+            </ref></p></abstract>
+      </profileDesc>
+      <revisionDesc>
+         <change who="ES" when="2025-07-15">created keyword</change>         
+      </revisionDesc>
+   </teiHeader>
+   <text xml:base="https://betamasaheft.eu/">
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/ChurchSchools/QeddaseBet.xml
+++ b/ChurchSchools/QeddaseBet.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="auth" xml:id="QeddaseBet">
+   <teiHeader xml:base="https://betamasaheft.eu/">
+      <fileDesc>
+         <titleStmt>
+            <title>Qǝddāse bet</title>
+            <editor key="ES"/>
+            <editor key="AB" role="generalEditor"/>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+            <pubPlace>Hamburg</pubPlace>
+            <availability>
+               <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                            licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                     href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+            <xi:fallback>
+               <p>Definitions of prefixes used.</p>
+            </xi:fallback>
+         </xi:include>
+      </encodingDesc>
+      <profileDesc>
+         <abstract><p>Church school (school of liturgy).
+            
+            See also          
+            <ref type="authFile" corresp="NebabBet"/>,  
+            <ref  type="authFile" corresp="QeneBet"></ref>,
+            <ref  type="authFile" corresp="ZemaBet"></ref>, <ref  type="authFile" corresp="MashafBet"></ref></p></abstract>
+      </profileDesc>
+      <revisionDesc>
+         <change who="ES" when="2025-07-15">created keyword</change>         
+      </revisionDesc>
+   </teiHeader>
+   <text xml:base="https://betamasaheft.eu/">
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/ChurchSchools/QeneBet.xml
+++ b/ChurchSchools/QeneBet.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="auth" xml:id="QeneBet">
+   <teiHeader xml:base="https://betamasaheft.eu/">
+      <fileDesc>
+         <titleStmt>
+            <title>Qǝne bet</title>
+            <editor key="ES"/>
+            <editor key="AB" role="generalEditor"/>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+            <pubPlace>Hamburg</pubPlace>
+            <availability>
+               <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                            licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                     href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+            <xi:fallback>
+               <p>Definitions of prefixes used.</p>
+            </xi:fallback>
+         </xi:include>
+      </encodingDesc>
+      <profileDesc>
+         <abstract><p>Church school (school of poetry).
+            
+            See also          
+            <ref type="authFile" corresp="NebabBet"/>,  
+            <ref  type="authFile" corresp="QeddaseBet"></ref>,
+            <ref  type="authFile" corresp="ZemaBet"></ref>, <ref  type="authFile" corresp="MashafBet"></ref></p></abstract>
+      </profileDesc>
+      <revisionDesc>
+         <change who="ES" when="2025-07-15">created keyword</change>         
+      </revisionDesc>
+   </teiHeader>
+   <text xml:base="https://betamasaheft.eu/">
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/ChurchSchools/ZemaBet.xml
+++ b/ChurchSchools/ZemaBet.xml
@@ -31,7 +31,7 @@
       </encodingDesc>
       <profileDesc>
          <abstract><p>Church school (school of chant).
-            Can be specialized in <seg xml:id="Meraf">School of Mǝʿ rāf</seg>, <seg xml:id="Deggwa">School of Dǝggʷā</seg>, <seg xml:id="Aqwaqwam">School of ʾAqqʷāqʷām</seg> 
+            Can be specialized in <seg xml:id="Meraf">School of Mǝʿ rāf</seg>, <seg xml:id="Deggwa">School of Dǝggʷā</seg> (see e.g. <ref target="https://doi.org/10.25592/uhhfdm.14599">the interview with Māhtot Tasfā conducted on 16 May 2024</ref>), <seg xml:id="Aqwaqwam">School of ʾAqqʷāqʷām</seg> (see e.g. <ref target="https://doi.org/10.25592/uhhfdm.14599">the interview with Mamhǝr Kǝbur Tǝlāhun of 16 May 2024</ref>) 
             See also          
             <ref type="authFile" corresp="NebabBet"/>,  
             <ref  type="authFile" corresp="QeneBet"></ref>,

--- a/ChurchSchools/ZemaBet.xml
+++ b/ChurchSchools/ZemaBet.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" type="auth" xml:id="ZemaBet">
+   <teiHeader xml:base="https://betamasaheft.eu/">
+      <fileDesc>
+         <titleStmt>
+            <title>Zemā bet</title>
+            <editor key="ES"/>
+            <editor key="AB" role="generalEditor"/>
+            <funder>Akademie der Wissenschaften in Hamburg</funder>
+         </titleStmt>
+         <publicationStmt>
+            <authority>Hiob-Ludolf-Zentrum für Äthiopistik</authority>
+            <publisher>Die Schriftkultur des christlichen Äthiopiens und Eritreas: Eine multimediale Forschungsumgebung / Beta maṣāḥǝft</publisher>
+            <pubPlace>Hamburg</pubPlace>
+            <availability>
+               <licence target="http://creativecommons.org/licenses/by-sa/4.0/"> This file is
+                            licensed under the Creative Commons Attribution-ShareAlike 4.0. </licence>
+            </availability>
+         </publicationStmt>
+         <sourceDesc>
+            <p/>
+         </sourceDesc>
+      </fileDesc>
+      <encodingDesc>
+         <xi:include xmlns:xi="http://www.w3.org/2001/XInclude"
+                     href="https://raw.githubusercontent.com/BetaMasaheft/Documentation/master/prefixDef.xml">
+            <xi:fallback>
+               <p>Definitions of prefixes used.</p>
+            </xi:fallback>
+         </xi:include>
+      </encodingDesc>
+      <profileDesc>
+         <abstract><p>Church school (school of chant).
+            Can be specialized in <seg xml:id="Meraf">School of Mǝʿ rāf</seg>, <seg xml:id="Deggwa">School of Dǝggʷā</seg>, <seg xml:id="Aqwaqwam">School of ʾAqqʷāqʷām</seg> 
+            See also          
+            <ref type="authFile" corresp="NebabBet"/>,  
+            <ref  type="authFile" corresp="QeneBet"></ref>,
+            <ref  type="authFile" corresp="QeddaseBet"></ref>, <ref  type="authFile" corresp="MashafBet"></ref></p></abstract>
+      </profileDesc>
+      <revisionDesc>
+         <change who="ES" when="2025-07-15">created keyword</change>         
+      </revisionDesc>
+   </teiHeader>
+   <text xml:base="https://betamasaheft.eu/">
+      <body>
+         <p/>
+      </body>
+   </text>
+</TEI>

--- a/taxonomy.xml
+++ b/taxonomy.xml
@@ -16,6 +16,24 @@
             <catDesc>Miniature Collection</catDesc>
          </category>
       </category>
+       <category>
+          <desc>Church Schools</desc>
+          <category xml:id="NebabBet" corresp="https://betamasaheft.eu/authority-files/NebabBet/main">
+             <catDesc>Nǝbāb bet</catDesc>
+          </category>
+          <category xml:id="QeddaseBet" corresp="https://betamasaheft.eu/authority-files/QeddaseBet/main">
+             <catDesc>Qǝddāse bet</catDesc>
+          </category>
+          <category xml:id="ZemaBet" corresp="https://betamasaheft.eu/authority-files/ZemaBet/main">
+             <catDesc>Zemā bet</catDesc>
+          </category>          
+          <category xml:id="QeneBet" corresp="https://betamasaheft.eu/authority-files/QeneBet/main">
+             <catDesc>Qǝne bet</catDesc>
+          </category>         
+          <category xml:id="MashafBet" corresp="https://betamasaheft.eu/authority-files/MashafBet/main">
+             <catDesc>Maṣḥāf bet</catDesc>
+          </category>
+       </category>
       <category>
          <desc>Objects of Veneration</desc>
          <category xml:id="TrueCross" corresp="https://betamasaheft.eu/authority-files/TrueCross/main">


### PR DESCRIPTION
https://github.com/BetaMasaheft/Documentation/issues/3065

taxonomy of church schools for Abennat metadata

I hope I understand correctly that Deggwa and Aqqwaqwam are part of Zema bet and Andemta is part of Mashaf bet. Thank you for verifying.